### PR TITLE
Add default request start time.

### DIFF
--- a/lib/context_request_middleware/middleware.rb
+++ b/lib/context_request_middleware/middleware.rb
@@ -101,7 +101,7 @@ module ContextRequestMiddleware
       ContextRequestMiddleware.select_request_headers(
         ContextRequestMiddleware.request_start_time_headers,
         request
-      ) || Time.current
+      ) || Time.now.to_f
     end
 
     def source(request)

--- a/lib/context_request_middleware/middleware.rb
+++ b/lib/context_request_middleware/middleware.rb
@@ -101,7 +101,7 @@ module ContextRequestMiddleware
       ContextRequestMiddleware.select_request_headers(
         ContextRequestMiddleware.request_start_time_headers,
         request
-      )
+      ) || Time.current
     end
 
     def source(request)

--- a/lib/context_request_middleware/middleware.rb
+++ b/lib/context_request_middleware/middleware.rb
@@ -101,7 +101,7 @@ module ContextRequestMiddleware
       ContextRequestMiddleware.select_request_headers(
         ContextRequestMiddleware.request_start_time_headers,
         request
-      ) || Time.now.to_f
+      ) || (defined?(Time.current) ? Time.current : Time.now).to_f
     end
 
     def source(request)

--- a/spec/lib/context_request_middleware/middleware_spec.rb
+++ b/spec/lib/context_request_middleware/middleware_spec.rb
@@ -106,23 +106,55 @@ module ContextRequestMiddleware
           Rack::MockRequest.env_for('/some/path',
                                     'CONTENT_TYPE' => 'text/plain')
         end
-        let(:request_data) do
-          {
-            host: 'example.org',
-            request_context: nil,
-            request_id: nil,
-            request_method: 'GET',
-            request_path: '/some/path',
-            request_params: {},
-            request_start_time: Time.now.to_f,
-            request_status: 200,
-            source: ''
-          }
+
+        context 'and undefined Time.current method' do
+          let(:request_data) do
+            {
+              host: 'example.org',
+              request_context: nil,
+              request_id: nil,
+              request_method: 'GET',
+              request_path: '/some/path',
+              request_params: {},
+              request_start_time: Time.now.to_f,
+              request_status: 200,
+              source: ''
+            }
+          end
+
+          it do
+            expect(push_handler).to receive(:push)
+              .with(request_data, **request_options).and_return(nil)
+            subject.call(env)
+          end
         end
-        it do
-          expect(push_handler).to receive(:push)
-            .with(request_data, **request_options).and_return(nil)
-          subject.call(env)
+
+        context 'and available Time.current method' do
+          let(:current_time) { Time.at(1_574_782_410.9173372) }
+          let(:request_data) do
+            {
+              host: 'example.org',
+              request_context: nil,
+              request_id: nil,
+              request_method: 'GET',
+              request_path: '/some/path',
+              request_params: {},
+              request_start_time: current_time.to_f,
+              request_status: 200,
+              source: ''
+            }
+          end
+
+          before do
+            allow(Time).to receive(:current)
+              .and_return(current_time)
+          end
+
+          it do
+            expect(push_handler).to receive(:push)
+              .with(request_data, **request_options).and_return(nil)
+            subject.call(env)
+          end
         end
       end
     end

--- a/spec/lib/context_request_middleware/middleware_spec.rb
+++ b/spec/lib/context_request_middleware/middleware_spec.rb
@@ -99,6 +99,32 @@ module ContextRequestMiddleware
           subject.call(env)
         end
       end
+
+      context 'with missing HTTP_X_REQUEST_START header' do
+        let(:app) { MockRackApp.new }
+        let(:env) do
+          Rack::MockRequest.env_for('/some/path',
+                                    'CONTENT_TYPE' => 'text/plain')
+        end
+        let(:request_data) do
+          {
+            host: 'example.org',
+            request_context: nil,
+            request_id: nil,
+            request_method: 'GET',
+            request_path: '/some/path',
+            request_params: {},
+            request_start_time: Time.now.to_f,
+            request_status: 200,
+            source: ''
+          }
+        end
+        it do
+          expect(push_handler).to receive(:push)
+            .with(request_data, **request_options).and_return(nil)
+          subject.call(env)
+        end
+      end
     end
 
     context 'with no sample-handler' do


### PR DESCRIPTION
Added a default value for the request time.

In our case there aren't any headers set by the application to hold the start time of the request ('HTTP_X_REQUEST_START', 'HTTP_X_QUEUE_START'), so we can set the "request_start_time" to Time.current.


