### PR TITLE
Extract owner_id to be configurable

### DIFF
--- a/lib/context_request_middleware.rb
+++ b/lib/context_request_middleware.rb
@@ -85,7 +85,8 @@ module ContextRequestMiddleware
   config_accessor(:context_retriever_version, instance_accessor: false)
 
   # Extract the user id from Main application
-  # Set in Main App ENV['cookie_session.user_id'] = current_user.id usually in application_controller
+  # Set in Main App ENV['cookie_session.user_id'] = current_user.id
+  # usually done in application_controller
   # so it can be applied to the context
   # @default cookie_session.user_id
   config_accessor(:session_owner_id, instance_accessor: false) do

--- a/lib/context_request_middleware.rb
+++ b/lib/context_request_middleware.rb
@@ -84,6 +84,14 @@ module ContextRequestMiddleware
   end
   config_accessor(:context_retriever_version, instance_accessor: false)
 
+  # Extract the user id from Main application
+  # Set in Main App ENV['cookie_session.user_id'] = current_user.id usually in application_controller
+  # so it can be applied to the context
+  # @default cookie_session.user_id
+  config_accessor(:session_owner_id, instance_accessor: false) do
+    'cookie_session.user_id'
+  end
+
   # Classname (small case) on how to push the data stored from the current
   # request.
   # @default rabbitmq_push_handler which means it pushes to RabbitMQ

--- a/lib/context_request_middleware/context/cookie_session_retriever.rb
+++ b/lib/context_request_middleware/context/cookie_session_retriever.rb
@@ -33,7 +33,7 @@ module ContextRequestMiddleware
       private
 
       def owner_id
-        from_env('cookie_session.user_id', 'unknown')
+        from_env(ContextRequestMiddleware.session_owner_id, 'unknown')
       end
 
       def context_status


### PR DESCRIPTION
add config accessor of **session_owner_id**
with default value 'cookie_session.user_id',
by extracting it I will have the ability to configure this properly
for my needs and in the same time I will not brake it in general
for other applications.