### PR TITLE
Update session retrieval logic

### DIFF
--- a/lib/context_request_middleware/context/cookie_session_retriever.rb
+++ b/lib/context_request_middleware/context/cookie_session_retriever.rb
@@ -20,7 +20,7 @@ module ContextRequestMiddleware
 
       def call(status, header, body)
         @response = Rack::Response.new(body, status, header)
-        if new_session_id?
+        if context_changed?
           data[:context_id] = session_id
           data[:owner_id] = owner_id
           data[:context_status] = context_status
@@ -44,13 +44,20 @@ module ContextRequestMiddleware
         'session_cookie'
       end
 
-      def new_session_id?
-        session_id && session_id != request_cookie_session_id
+      def context_changed?
+        new_session_id && new_session_id != request_cookie_session_id
       end
 
       def session_id
-        @session_id ||= set_cookie_header &&
-                        set_cookie_header.match(/_session_id=([^\;]+)/)[1]
+        new_session_id || request_cookie_session_id
+      end
+
+      def new_session_id
+        new_session = nil
+        session_id_header = set_cookie_header.match(/_session_id=([^\;]+)/) \
+            if set_cookie_header
+        new_session = session_id_header[1] if session_id_header
+        new_session
       end
 
       def request_cookie_session_id


### PR DESCRIPTION
Context didn't change properly when logging in/out from the app (stayed the same)
With these modifications every new session is caught and a context message is sent.