### PR TITLE
Passing data from host app to the middleware.

### DIFF
--- a/lib/context_request_middleware/context/cookie_session_retriever.rb
+++ b/lib/context_request_middleware/context/cookie_session_retriever.rb
@@ -62,7 +62,7 @@ module ContextRequestMiddleware
       end
 
       def from_env(key, default = nil)
-        @request.env.fetch(key, default)
+        ENV.fetch(key, default)
       end
     end
   end

--- a/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
+++ b/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
@@ -47,7 +47,7 @@ module ContextRequestMiddleware
                 app_id: 'anonymous' }
             end
             before do
-              request.env['cookie_session.user_id'] = user_id
+              ENV['cookie_session.user_id'] = user_id
             end
 
             it { expect(subject.call(*response.to_a)).to eq data }
@@ -57,7 +57,7 @@ module ContextRequestMiddleware
             context 'with different sids' do
               let(:new_sid) { RackSessionCookie.generate_sid }
               before do
-                request.env['cookie_session.user_id'] = user_id
+                ENV['cookie_session.user_id'] = user_id
                 request.env['HTTP_COOKIE'] =
                   Rack::Utils.add_cookie_to_header(nil, '_session_id', new_sid)
               end

--- a/spec/lib/context_request_middleware/middleware_spec.rb
+++ b/spec/lib/context_request_middleware/middleware_spec.rb
@@ -23,6 +23,7 @@ module ContextRequestMiddleware
       end
 
       before do
+        ENV['cookie_session.user_id'] = nil
         Timecop.freeze
         allow(ContextRequestMiddleware).to receive(:push_handler)
           .and_return(push_handler_name)


### PR DESCRIPTION
Use ENV.fetch instead of @request.env.fetch for retrieving of data, that was set in the host application.

example:
 - Setting in host application: ENV['cookie_session.user_id'] = current_user&.id
 - Getting in the middleware: ENV['cookie_session.user_id'] works fine

note:
We tested to set the variable in the host app like this:
request.env['cookie_session.user_id'] = current_user&.id
For some reason @request.env.fetch('cookie_session.user_id', default) returns nil (in the middleware) 
This could be a quick fix while we figure out the root of the problem.