### PR TITLE
Catch errors and log them, preventing parent application from crashing.

### DIFF
--- a/context-request-middleware.gemspec
+++ b/context-request-middleware.gemspec
@@ -17,6 +17,7 @@ requests and their contexts.)
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'bunny'
   s.add_runtime_dependency 'connection_pool'
+  s.add_runtime_dependency 'logger'
   s.add_development_dependency 'license_finder'
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rake', '~> 13'

--- a/lib/context_request_middleware.rb
+++ b/lib/context_request_middleware.rb
@@ -13,6 +13,7 @@ require 'context_request_middleware/request'
 require 'context_request_middleware/context'
 require 'context_request_middleware/push_handler'
 require 'context_request_middleware/sampling_handler/accept_all'
+require 'context_request_middleware/error_logger'
 
 # :nodoc:
 module ContextRequestMiddleware
@@ -121,6 +122,12 @@ module ContextRequestMiddleware
     'accept_all'
   end
   config_accessor(:sampling_handler_version, instance_accessor: false)
+
+  # Array to specify the logger tags
+  # @default ['CONTEXT_REQUEST_MIDDLEWARE']
+  config_accessor(:logger_tags, instance_accessor: false) do
+    ['CONTEXT_REQUEST_MIDDLEWARE']
+  end
 
   # retrieves a class that is loaded from the root_pathname and
   # suffixed with both name and version.

--- a/lib/context_request_middleware/error_logger.rb
+++ b/lib/context_request_middleware/error_logger.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ContextRequestMiddleware
+  # Logger module to provide logging of errors
+  module ErrorLogger
+    extend self
+
+    # runs block of code and logs an error if any occurs
+    def error_handler
+      yield
+    rescue StandardError => e
+      logger.tagged(ContextRequestMiddleware.logger_tags) do
+        logger.error e.message + e.backtrace.join('\n')
+      end
+    end
+
+    # Returns logger from these options:
+    # option 1: Rails.logger, as defined in the host application
+    # option 2: new instance of ActiveSupport::TaggedLogging class
+    def logger(logger = Logger)
+      @logger ||= if defined?(Rails.logger.tagged)
+                    # :nocov:
+                    Rails.logger
+                    # :nocov:
+                  else
+                    ActiveSupport::TaggedLogging.new(logger)
+                  end
+    end
+  end
+end

--- a/lib/context_request_middleware/middleware.rb
+++ b/lib/context_request_middleware/middleware.rb
@@ -8,17 +8,21 @@ module ContextRequestMiddleware
       @data = {}
     end
 
+    # rubocop:disable Metrics/MethodLength
     def call(env)
       request = ContextRequestMiddleware.request_class.new(env)
       request(request) if valid_sample?(request)
       status, header, body = @app.call(env)
-      if valid_sample?(request)
-        response(status, header, body)
-        @context = context(status, header, body, request)
-        push
+      ContextRequestMiddleware::ErrorLogger.error_handler do
+        if valid_sample?(request)
+          response(status, header, body)
+          @context = context(status, header, body, request)
+          push
+        end
       end
       [status, header, body]
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/spec/lib/context_request_middleware/middleware_spec.rb
+++ b/spec/lib/context_request_middleware/middleware_spec.rb
@@ -27,6 +27,8 @@ module ContextRequestMiddleware
         Timecop.freeze
         allow(ContextRequestMiddleware).to receive(:push_handler)
           .and_return(push_handler_name)
+        allow(ContextRequestMiddleware).to receive(:logger_tags)
+          .and_return('TEST_TAG')
         allow(ContextRequestMiddleware::PushHandler)
           .to receive(:from_middleware).and_return(push_handler)
         allow(SecureRandom).to receive(:uuid)
@@ -98,6 +100,14 @@ module ContextRequestMiddleware
           expect(push_handler).to receive(:push)
             .with(context_data, context_options).and_return(nil)
           subject.call(env)
+        end
+
+        it do
+          output = StringIO.new
+          Logger = Logger.new(output)
+          allow(push_handler).to receive(:push).and_raise(StandardError)
+          expect { subject.call(env) }.to_not raise_error
+          expect(output.string).to include '[TEST_TAG]'
         end
       end
 


### PR DESCRIPTION
There is a case when RabbitMQ is not up and running and the middleware throws an error, crashing the parent application. We can now catch and log those errors using parent app logger.