### PR TITLE
Async rabbitmq push handler.

### DIFF
--- a/context-request-middleware.gemspec
+++ b/context-request-middleware.gemspec
@@ -18,6 +18,7 @@ requests and their contexts.)
   s.add_runtime_dependency 'bunny'
   s.add_runtime_dependency 'connection_pool'
   s.add_runtime_dependency 'logger'
+  s.add_runtime_dependency 'rabbitmq_client'
   s.add_development_dependency 'license_finder'
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rake', '~> 13'

--- a/lib/context_request_middleware/push_handler.rb
+++ b/lib/context_request_middleware/push_handler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'context_request_middleware/push_handler/rabbitmq_push_handler'
+require 'context_request_middleware/push_handler/rabbitmq_push_handler_async'
 
 module ContextRequestMiddleware
   # :nodoc:

--- a/lib/context_request_middleware/push_handler/rabbitmq_push_handler_async.rb
+++ b/lib/context_request_middleware/push_handler/rabbitmq_push_handler_async.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rabbitmq_client'
+require 'context_request_middleware/push_handler/base'
+
+module ContextRequestMiddleware
+  module PushHandler
+    # PushHandler that publishes the data given to a RabbitMQ exchange.
+    # If the exchange is not existent it will be created. The session is
+    # taken from the session_pool.
+    class RabbitmqPushHandlerAsync < Base
+      # Setup the publisher with configuring via the config options. The
+      # following config options are supported:
+      # @rabbitmq_url url to connect to RabbitMQ
+      # @pool_size size of the connection pool to be used. Defaults to 1
+      # @session_params a hash defining the params passed to the session.
+      # @heartbeat_publisher heartbeat interval used to communicate with
+      #    RabbitMQ.
+      # @exchange_name name of the exchange defaults to 'fos.context_request'
+      # @exchange_type type of the exchange defaults to ''
+      # @exchange_options options passed to the exchange if it has to be
+      #    created.
+      def initialize(**config)
+        @config = config.dup
+        exchange = RabbitmqClient::ExchangeRegistry.new
+        exchange.add(exchange_name, exchange_type, exchange_options)
+        @config[:exchange_registry] = exchange
+        @publisher = RabbitmqClient::Publisher.new(@config)
+        config_clean
+      end
+
+      # Publishes the given data on the exchange.
+      # @data a hash representing the data to be published.
+      # @options options to be passed to the publish to the exchange.
+      def push(data, options)
+        @publisher.publish(data.dup,
+                           options.dup.merge(exchange_name: exchange_name))
+      end
+
+      private
+
+      def config_clean
+        @config.delete(:rabbitmq_url)
+        @config.delete(:session_params)
+        @config.delete(:heartbeat)
+      end
+
+      def exchange_name
+        @exchange_name ||= @config.fetch(:exchange_name, 'fos.context_request')
+      end
+
+      def exchange_type
+        @config.fetch(:exchange_type, 'topic')
+      end
+
+      def exchange_options
+        @config.fetch(:exchange_options, {})
+      end
+    end
+  end
+end

--- a/spec/lib/context_request_middleware/push_handler/rabbitmq_push_handler_async_spec.rb
+++ b/spec/lib/context_request_middleware/push_handler/rabbitmq_push_handler_async_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ContextRequestMiddleware
+  module PushHandler
+    RSpec.describe RabbitmqPushHandlerAsync do
+      let(:exchange_name) { 'exchange' }
+      let(:confirmed) { true }
+      let(:publisher) { double('RabbitmqClient::Publisher') }
+
+      describe '#push' do
+        before do
+          allow(RabbitmqClient::Publisher).to receive(:new)
+            .and_return(publisher)
+          allow(publisher).to receive(:publish)
+            .and_return(:confirmed)
+        end
+        context 'with minimum config' do
+          subject { described_class.new(exchange_name: exchange_name) }
+          it { expect(subject.push({}, {})).to eq(:confirmed) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added a new rabbitmq push handler that utilizes this gem:
https://github.com/wshihadeh/rabbitmq_client
 - It uses both bunny and connection_pool to manage RabbitMQ communications.
 - Uses Sucker Punch gem: single-process Ruby asynchronous processing library.