### PR TITLE
Make this middleware thread safe

### DIFF
--- a/context-request-middleware.gemspec
+++ b/context-request-middleware.gemspec
@@ -19,6 +19,7 @@ requests and their contexts.)
   s.add_runtime_dependency 'connection_pool'
   s.add_runtime_dependency 'logger'
   s.add_runtime_dependency 'rabbitmq_client'
+  s.add_runtime_dependency 'request_store'
   s.add_development_dependency 'license_finder'
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rake', '~> 13'

--- a/lib/context_request_middleware.rb
+++ b/lib/context_request_middleware.rb
@@ -4,6 +4,7 @@ require 'active_support'
 require 'active_support/inflector'
 require 'rack'
 require 'securerandom'
+require 'request_store'
 
 require 'context_request_middleware/railtie' if defined?(Rails)
 require 'context_request_middleware/sampling_handler'

--- a/lib/context_request_middleware/context/cookie_session_retriever.rb
+++ b/lib/context_request_middleware/context/cookie_session_retriever.rb
@@ -69,7 +69,7 @@ module ContextRequestMiddleware
       end
 
       def from_thread_var(key, default = nil)
-        Thread.current[key] || default
+        RequestStore.store[key] || default
       end
     end
   end

--- a/lib/context_request_middleware/context/cookie_session_retriever.rb
+++ b/lib/context_request_middleware/context/cookie_session_retriever.rb
@@ -69,7 +69,13 @@ module ContextRequestMiddleware
       end
 
       def from_env(key, default = nil)
-        ENV.fetch(key, default)
+        ENV.fetch(key + '.' + request_id.to_s, default)
+      end
+
+      def request_id
+        @request_id ||= ContextRequestMiddleware.select_request_headers(
+          ContextRequestMiddleware.request_id_headers, @request
+        )
       end
     end
   end

--- a/lib/context_request_middleware/context/cookie_session_retriever.rb
+++ b/lib/context_request_middleware/context/cookie_session_retriever.rb
@@ -37,11 +37,11 @@ module ContextRequestMiddleware
       private
 
       def owner_id
-        from_env(ContextRequestMiddleware.session_owner_id, 'unknown')
+        from_thread_var(ContextRequestMiddleware.session_owner_id, 'unknown')
       end
 
       def context_status
-        from_env(ContextRequestMiddleware.context_status, 'unknown')
+        from_thread_var(ContextRequestMiddleware.context_status, 'unknown')
       end
 
       def context_type
@@ -68,14 +68,8 @@ module ContextRequestMiddleware
         @response.headers.fetch(HTTP_HEADER, nil)
       end
 
-      def from_env(key, default = nil)
-        ENV.fetch(key + '.' + request_id.to_s, default)
-      end
-
-      def request_id
-        @request_id ||= ContextRequestMiddleware.select_request_headers(
-          ContextRequestMiddleware.request_id_headers, @request
-        )
+      def from_thread_var(key, default = nil)
+        Thread.current[key] || default
       end
     end
   end

--- a/lib/context_request_middleware/middleware.rb
+++ b/lib/context_request_middleware/middleware.rb
@@ -25,7 +25,6 @@ module ContextRequestMiddleware
         push_context
         push if valid_sample?(request)
       end
-      env_cleanup(request)
       [status, header, body]
     end
     # rubocop:enable Metrics/MethodLength
@@ -139,15 +138,6 @@ module ContextRequestMiddleware
       @request_id ||= ContextRequestMiddleware.select_request_headers(
         ContextRequestMiddleware.request_id_headers, request
       )
-    end
-
-    def env_cleanup(request)
-      env_delete(ContextRequestMiddleware.session_owner_id, request)
-      env_delete(ContextRequestMiddleware.context_status, request)
-    end
-
-    def env_delete(key, request)
-      ENV.delete(key + '.' + request_id(request).to_s)
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/context_request_middleware/push_handler/rabbitmq_push_handler_async.rb
+++ b/lib/context_request_middleware/push_handler/rabbitmq_push_handler_async.rb
@@ -33,8 +33,8 @@ module ContextRequestMiddleware
       # @data a hash representing the data to be published.
       # @options options to be passed to the publish to the exchange.
       def push(data, options)
-        @publisher.publish(data.dup,
-                           options.dup.merge(exchange_name: exchange_name))
+        @publisher.publish(data,
+                           options.merge(exchange_name: exchange_name))
       end
 
       private

--- a/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
+++ b/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
@@ -48,7 +48,7 @@ module ContextRequestMiddleware
                 app_id: 'anonymous' }
             end
             before do
-              ENV['cookie_session.user_id.test-request-id'] = user_id
+              Thread.current['cookie_session.user_id'] = user_id
             end
 
             it { expect(subject.call(*response.to_a)).to eq data }
@@ -58,7 +58,8 @@ module ContextRequestMiddleware
             context 'with different sids' do
               let(:new_sid) { RackSessionCookie.generate_sid }
               before do
-                ENV['cookie_session.user_id.test-request-id'] = user_id
+                Thread.current['cookie_session.user_id'] = user_id
+
                 request.env['HTTP_COOKIE'] =
                   Rack::Utils.add_cookie_to_header(nil, '_session_id', new_sid)
               end

--- a/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
+++ b/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
@@ -12,7 +12,8 @@ module ContextRequestMiddleware
       let(:env) do
         Rack::MockRequest.env_for('/some/path',
                                   'CONTENT_TYPE' => 'text/plain',
-                                  'HTTP_X_REQUEST_START' => Time.now.to_f)
+                                  'HTTP_X_REQUEST_START' => Time.now.to_f,
+                                  'HTTP_X_REQUEST_ID' => 'test-request-id')
       end
       let(:response) { Rack::Response.new(['OK'], 200, header) }
       let(:request) { Rack::Request.new(env) }
@@ -47,7 +48,7 @@ module ContextRequestMiddleware
                 app_id: 'anonymous' }
             end
             before do
-              ENV['cookie_session.user_id'] = user_id
+              ENV['cookie_session.user_id.test-request-id'] = user_id
             end
 
             it { expect(subject.call(*response.to_a)).to eq data }
@@ -57,7 +58,7 @@ module ContextRequestMiddleware
             context 'with different sids' do
               let(:new_sid) { RackSessionCookie.generate_sid }
               before do
-                ENV['cookie_session.user_id'] = user_id
+                ENV['cookie_session.user_id.test-request-id'] = user_id
                 request.env['HTTP_COOKIE'] =
                   Rack::Utils.add_cookie_to_header(nil, '_session_id', new_sid)
               end

--- a/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
+++ b/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
@@ -48,7 +48,7 @@ module ContextRequestMiddleware
                 app_id: 'anonymous' }
             end
             before do
-              Thread.current['cookie_session.user_id'] = user_id
+              RequestStore.store['cookie_session.user_id'] = user_id
             end
 
             it { expect(subject.call(*response.to_a)).to eq data }
@@ -58,7 +58,7 @@ module ContextRequestMiddleware
             context 'with different sids' do
               let(:new_sid) { RackSessionCookie.generate_sid }
               before do
-                Thread.current['cookie_session.user_id'] = user_id
+                RequestStore.store['cookie_session.user_id'] = user_id
 
                 request.env['HTTP_COOKIE'] =
                   Rack::Utils.add_cookie_to_header(nil, '_session_id', new_sid)

--- a/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
+++ b/spec/lib/context_request_middleware/context/cookie_session_retriever_spec.rb
@@ -12,8 +12,7 @@ module ContextRequestMiddleware
       let(:env) do
         Rack::MockRequest.env_for('/some/path',
                                   'CONTENT_TYPE' => 'text/plain',
-                                  'HTTP_X_REQUEST_START' => Time.now.to_f,
-                                  'HTTP_X_REQUEST_ID' => 'test-request-id')
+                                  'HTTP_X_REQUEST_START' => Time.now.to_f)
       end
       let(:response) { Rack::Response.new(['OK'], 200, header) }
       let(:request) { Rack::Request.new(env) }

--- a/spec/lib/context_request_middleware/middleware_spec.rb
+++ b/spec/lib/context_request_middleware/middleware_spec.rb
@@ -113,11 +113,16 @@ module ContextRequestMiddleware
             app_id: 'anonymous'
           }
         end
+
+        before do
+          RequestStore.delete('cookie_session.user_id')
+        end
+
         it do
           expect(push_handler).to receive(:push)
-            .with(request_data, request_options).and_return(nil)
-          expect(push_handler).to receive(:push)
             .with(context_data, context_options).and_return(nil)
+          expect(push_handler).to receive(:push)
+            .with(request_data, request_options).and_return(nil)
           subject.call(env)
         end
 

--- a/spec/lib/context_request_middleware/middleware_spec.rb
+++ b/spec/lib/context_request_middleware/middleware_spec.rb
@@ -222,6 +222,29 @@ module ContextRequestMiddleware
                        ['OK']]
         end
       end
+
+      context 'thread safe' do
+        let(:app) { MockRackApp.new }
+        let(:env) do
+          Rack::MockRequest
+            .env_for('/some/path', 'CONTENT_TYPE' => 'text/plain')
+        end
+
+        before do
+          allow(subject).to receive(:_call)
+            .and_call_original
+          allow(push_handler).to receive(:push)
+            .and_return(nil)
+        end
+
+        it do
+          # assert that _call is called
+          # on a duped instance rather than the original.
+          expect(subject).not_to have_received(:_call)
+          expect_any_instance_of(Middleware).to receive(:_call)
+          subject.call(env)
+        end
+      end
     end
 
     after do

--- a/spec/lib/context_request_middleware/middleware_spec.rb
+++ b/spec/lib/context_request_middleware/middleware_spec.rb
@@ -187,38 +187,40 @@ module ContextRequestMiddleware
           end
         end
       end
-    end
 
-    context 'with no sample-handler' do
-      let(:sid) { RackSessionCookie.generate_sid }
-      let(:app) { MockRackAppWithSession.new(sid) }
-      let(:env) do
-        Rack::MockRequest
-          .env_for('/some/path', 'CONTENT_TYPE' => 'text/plain',
-                                 'HTTP_X_REQUEST_START' => Time.now.to_f)
-      end
-      let(:request_data) do
-        {
-          app_id: 'anonymous',
-          host: 'example.org',
-          request_context: sid,
-          request_id: nil,
-          request_method: 'GET',
-          request_path: '/some/path',
-          request_params: {},
-          request_start_time: Time.now.to_f,
-          request_status: 200,
-          source: ''
-        }
-      end
-      before do
-        allow(ContextRequestMiddleware).to receive(:sampling_handler)
-          .and_return(nil)
-      end
-      it do
-        expect(subject.call(env))
-          .to match [200, a_hash_including('Content-Type' => 'text/plain'),
-                     ['OK']]
+      context 'with no sample-handler' do
+        let(:sid) { RackSessionCookie.generate_sid }
+        let(:app) { MockRackAppWithSession.new(sid) }
+        let(:env) do
+          Rack::MockRequest
+            .env_for('/some/path', 'CONTENT_TYPE' => 'text/plain',
+                                   'HTTP_X_REQUEST_START' => Time.now.to_f)
+        end
+        let(:request_data) do
+          {
+            app_id: 'anonymous',
+            host: 'example.org',
+            request_context: sid,
+            request_id: nil,
+            request_method: 'GET',
+            request_path: '/some/path',
+            request_params: {},
+            request_start_time: Time.now.to_f,
+            request_status: 200,
+            source: ''
+          }
+        end
+        before do
+          allow(ContextRequestMiddleware).to receive(:sampling_handler)
+            .and_return(nil)
+          allow(push_handler).to receive(:push)
+            .and_return(nil)
+        end
+        it do
+          expect(subject.call(env))
+            .to match [200, a_hash_including('Content-Type' => 'text/plain'),
+                       ['OK']]
+        end
       end
     end
 

--- a/spec/lib/context_request_middleware/middleware_spec.rb
+++ b/spec/lib/context_request_middleware/middleware_spec.rb
@@ -32,7 +32,7 @@ module ContextRequestMiddleware
       end
 
       before do
-        ENV['cookie_session.user_id'] = nil
+        Thread.current['cookie_session.user_id'] = nil
         Timecop.freeze
         allow(ContextRequestMiddleware).to receive(:push_handler)
           .and_return(push_handler_name)


### PR DESCRIPTION
There were issues while running multiple concurrent requests - variables were randomly overwritten and unexpected behaviour was observed.

This PR includes the filter improvement one: https://github.com/MarcGrimme/context-request-middleware/pull/14